### PR TITLE
Fix SQL query typo in termination process

### DIFF
--- a/terminate.php
+++ b/terminate.php
@@ -19,7 +19,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['id'])) {
     if (mysqli_num_rows($result_check) > 0) {
         // Insert terminated record into the terminate table
         $query_insert = "INSERT INTO terminate (id, status, department, category, pic, service, company, start, endDate, rent, remarks, duration, termination_date)
-                         SELECT id, status, department, category, pic, service, company, start, endDate, rent, remarks, duration NOW() 
+                         SELECT id, status, department, category, pic, service, company, start, endDate, rent, remarks, duration, NOW() 
                          FROM form WHERE id = '$id'";
 
         if (mysqli_query($connection, $query_insert)) {


### PR DESCRIPTION
## Summary
- fix SQL syntax error in `terminate.php`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68745fbb62948323a54dac760b244099