### PR TITLE
Fix update form status and responsive layout

### DIFF
--- a/editForm.php
+++ b/editForm.php
@@ -42,6 +42,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $rent = htmlspecialchars($_POST['rent']);
     $remarks = htmlspecialchars($_POST['remarks']);
     $duration = htmlspecialchars($_POST['duration']);
+    $status = isset($_POST['status']) ? htmlspecialchars($_POST['status']) : $row['status'];
 
 
     // Directory for file uploads
@@ -138,7 +139,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             margin: 0;
         }
         .container {
-            max-width: 600px;
+            width: 90%;
+            max-width: 900px;
             margin: 15px auto;
             padding: 30px;
             background-color: white;
@@ -166,17 +168,17 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             padding: 5px;
             border: 1px solid #ddd;
             border-radius: 8px;
-            width: 80%;
+            width: 100%;
             font-size: 16px;
             background-color: #f9f9f9;
         }
         input[type="date"], input[type="number"] {
-            width: 80%;
+            width: 100%;
         }
         textarea {
             height: 80px;
             resize: none;
-            width: 80%;
+            width: 100%;
         }
         .button {
             background-color: blue;
@@ -263,7 +265,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         <textarea name="duration" id="duration" ><?php echo $row['duration']; ?></textarea>
 
         <label for="files">Upload Files:</label>
-        <input type="file" name="files[]" id="files" value="<?php echo htmlspecialchars($row['file']); ?>" multiple>
+        <input type="file" name="files[]" id="files" value="<?php echo htmlspecialchars($row['filename']); ?>" multiple>
 
         <h3>Existing Files:</h3>
         <ul>
@@ -302,6 +304,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         </ul>
 
         <input type="hidden" name="file_names_string" value="<?php echo $row['filename']; ?>">
+        <input type="hidden" name="status" value="<?php echo htmlspecialchars($row['status']); ?>">
         <button type="submit" class="btn">Update</button>
     </form>
 </div>

--- a/form.php
+++ b/form.php
@@ -146,7 +146,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             margin: 0;
         }
         .container {
-            max-width: 600px;
+            width: 90%;
+            max-width: 900px;
             max-height: px;
             margin: 15px auto;
             padding: 30px;
@@ -175,17 +176,17 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             padding: 5px;
             border: 1px solid #ddd;
             border-radius: 8px;
-            width: 80%;
+            width: 100%;
             font-size: 16px;
             background-color: #f9f9f9;
         }
         input[type="date"], input[type="number"] {
-            width: 80%;
+            width: 100%;
         }
         textarea {
             height: 80px;
             resize: none;
-            width: 80%;
+            width: 100%;
         }
 
         .button {

--- a/terminate.php
+++ b/terminate.php
@@ -19,7 +19,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['id'])) {
     if (mysqli_num_rows($result_check) > 0) {
         // Insert terminated record into the terminate table
         $query_insert = "INSERT INTO terminate (id, status, department, category, pic, service, company, start, endDate, rent, remarks, duration, termination_date)
-                         SELECT id, status, department, category, pic, service, company, start, endDate, rent, remarks, duration NOW() 
+                         SELECT id, status, department, category, pic, service, company, start, endDate, rent, remarks, duration, NOW() 
                          FROM form WHERE id = '$id'";
 
         if (mysqli_query($connection, $query_insert)) {


### PR DESCRIPTION
## Summary
- keep existing record status during update
- widen edit and create form containers and fields
- correct filename reference in edit form

## Testing
- `php -l editForm.php`
- `php -l form.php`
- `php -l terminate.php`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68745fbb62948323a54dac760b244099